### PR TITLE
added mobile classes to 404 page

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -8,7 +8,7 @@
 
     <div class="container mt-5">
         <div class="row">
-            <div class="col-6 offset-3 display-1 text-center">
+            <div class="col-lg-6 offset-lg-3 col-sm-12 offset-sm-0 display-1 text-center">
 
                 <!-- line 01 -->
                 <div class="row text-danger">


### PR DESCRIPTION
Regarding issue #153 I updated the bootstrap classes on 404 page.

![image](https://user-images.githubusercontent.com/5655764/94954972-23896f80-04ea-11eb-81c9-36f0c3c4299a.png)
